### PR TITLE
Add functionality for actor token exchanges

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,6 +178,7 @@ func (s *server) handleRequest(res http.ResponseWriter, req *http.Request) {
 				Scopes:       strings.Split(s.Scope, ","),
 				TokenURL:     s.TokenUrl,
 				EndpointParams: url.Values{
+					"grant_type":           {"urn:ietf:params:oauth:grant-type:token-exchange"},
 					"requested_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
 					s.SubjectField:         {subject},
 				},


### PR DESCRIPTION
- If TOKEN_EXCHANGE_AUTH_MODE is set to ACTOR_TOKEN, the additional step to fetch an actor token is performed
- Default is CLIENT_CREDENTIALS as before, so nothing changes for current usage
- if TOKEN_EXCHANGE_SUBJECT_FIELD is not set, default is "subject" which is then taken from the request header x-subject
